### PR TITLE
Buslint for large gems projects

### DIFF
--- a/buslint.cpp
+++ b/buslint.cpp
@@ -7,6 +7,7 @@
 #include <tuple>
 #include <regex>
 #include <fstream>
+#include <sstream>
 
 
 class Components
@@ -98,10 +99,19 @@ int main( int argc, char** argv )
         return 0;
     }
 
+    using namespace std;
+    // read contents of files to parse from the file
+    ifstream t(argv[1]);
+    string str((istreambuf_iterator<char>(t)), istreambuf_iterator<char>());
+
+    istringstream ss(str);
+
     std::vector<std::string> components{};
-    for ( int i = 1; i < argc; i++ )
+
+    string one_line;
+    while (getline(ss, one_line, ' '))
     {
-        components.emplace_back( argv[i] );
+        components.emplace_back( one_line );
     }
 
     App app( components );

--- a/buslint.py
+++ b/buslint.py
@@ -16,6 +16,7 @@ from waflib.TaskGen import feature, after_method, before_method
 from waflib import Task, Logs, Utils, Errors
 from waflib.Context import BOTH
 import time
+import tempfile
 
 @feature('buslint')
 @after_method('process_source')
@@ -30,7 +31,7 @@ def create_buslint_tasks(self):
         return
 
     componentHeaders = [s for s in self.header_files if "Component.h" in str(s)]
-    
+
     binary = self.bld.path.abspath() + "\\buslint.exe"
     inputs = self.to_nodes(self.source) + self.to_nodes(self.header_files)
 
@@ -49,9 +50,16 @@ class buslint(Task.Task):
 
     def run(self):
         args = self.input_paths
-        
+
+        # args might be more than 32k characters long, so let's write to a file and pass it to buslist
+        f = tempfile.NamedTemporaryFile(delete=False)
+        f.write(args)
+        f.close()
+
+        print("Buslint wrote to temp file: " + str(f.name))
+
         start_time = time.time()
-        success = self.exec_buslint(args)
+        success = self.exec_buslint(f.name)
         elapsed_time = time.time() - start_time
         print("Buslint took " + str(elapsed_time) + "s to run! ")
 
@@ -75,4 +83,3 @@ class buslint(Task.Task):
             return False # do not fail the build, this is a warning
 
         return True
-        

--- a/buslint.py
+++ b/buslint.py
@@ -17,6 +17,7 @@ from waflib import Task, Logs, Utils, Errors
 from waflib.Context import BOTH
 import time
 import tempfile
+import os
 
 @feature('buslint')
 @after_method('process_source')
@@ -56,12 +57,12 @@ class buslint(Task.Task):
         f.write(args)
         f.close()
 
-        print("Buslint wrote to temp file: " + str(f.name))
-
         start_time = time.time()
         success = self.exec_buslint(f.name)
         elapsed_time = time.time() - start_time
         print("Buslint took " + str(elapsed_time) + "s to run! ")
+
+        os.unlink(f.name)
 
         return 0 if success else 1
 


### PR DESCRIPTION
I tested original buslint with LmbrCentral gem and it failed due to a process limitation in Windows on 32k characters. To fix, I wrote out the list of files into a temp file and modified buslint.exe to read in a file instead of a direct list of inputs.